### PR TITLE
Fix unlearning data and MIA utilities

### DIFF
--- a/src/dataio/dataset.py
+++ b/src/dataio/dataset.py
@@ -18,6 +18,27 @@ from torchvision.datasets import CIFAR10, CIFAR100, SVHN, ImageFolder
 from tqdm import tqdm
 
 
+def _first_existing_attr(obj, attr_names):
+    for attr_name in attr_names:
+        if hasattr(obj, attr_name):
+            return attr_name
+    raise AttributeError(f"{type(obj).__name__} does not expose any of {attr_names}")
+
+
+def _take_indexed(values, indexes):
+    if isinstance(values, list):
+        return [values[int(index)] for index in indexes]
+    return values[indexes]
+
+
+def _assign_indexed(values, indexes, replacements):
+    if isinstance(values, list):
+        for index, replacement in zip(indexes, replacements):
+            values[int(index)] = replacement
+    else:
+        values[indexes] = replacements
+
+
 def cifar10_dataloaders_no_val(
     batch_size=128, data_dir="datasets/cifar10", num_workers=2
 ):
@@ -648,27 +669,27 @@ def cifar10_dataloaders(
 def replace_indexes(
     dataset: torch.utils.data.Dataset, indexes, seed=0, only_mark: bool = False
 ):
+    indexes = np.asarray(indexes, dtype=int)
+    label_attr = _first_existing_attr(dataset, ("targets", "labels", "_labels"))
+    labels = getattr(dataset, label_attr)
+
     if not only_mark:
         rng = np.random.RandomState(seed)
         new_indexes = rng.choice(
             list(set(range(len(dataset))) - set(indexes)), size=len(indexes)
         )
-        dataset.data[indexes] = dataset.data[new_indexes]
-        try:
-            dataset.targets[indexes] = dataset.targets[new_indexes]
-        except:
-            dataset.labels[indexes] = dataset.labels[new_indexes]
-        else:
-            dataset._labels[indexes] = dataset._labels[new_indexes]
+        data_attr = _first_existing_attr(dataset, ("data", "imgs"))
+        data = getattr(dataset, data_attr)
+        _assign_indexed(data, indexes, _take_indexed(data, new_indexes))
+        _assign_indexed(labels, indexes, _take_indexed(labels, new_indexes))
     else:
         # Notice the -1 to make class 0 work
-        try:
-            dataset.targets[indexes] = -dataset.targets[indexes] - 1
-        except:
-            try:
-                dataset.labels[indexes] = -dataset.labels[indexes] - 1
-            except:
-                dataset._labels[indexes] = -dataset._labels[indexes] - 1
+        old_labels = _take_indexed(labels, indexes)
+        if isinstance(old_labels, torch.Tensor):
+            new_labels = -old_labels - 1
+        else:
+            new_labels = -np.asarray(old_labels) - 1
+        _assign_indexed(labels, indexes, new_labels)
 
 
 def replace_class(

--- a/src/dataio/imagenet.py
+++ b/src/dataio/imagenet.py
@@ -133,15 +133,17 @@ def prepare_data(
     validation_set.set_transform(transform=validation_transform)
 
     if train_subset_indices is not None:
-        forget_indices = torch.ones_like(train_subset_indices) - train_subset_indices
-        train_subset_indices = torch.nonzero(train_subset_indices)
-
-        forget_indices = torch.nonzero(forget_indices)
-        retain_set = Subset(train_set, train_subset_indices)
+        retain_mask = train_subset_indices.bool()
+        forget_mask = ~retain_mask
+        retain_indices = torch.nonzero(retain_mask, as_tuple=True)[0].tolist()
+        forget_indices = torch.nonzero(forget_mask, as_tuple=True)[0].tolist()
+        retain_set = Subset(train_set, retain_indices)
         forget_set = Subset(train_set, forget_indices)
     if val_subset_indices is not None:
-        val_subset_indices = torch.nonzero(val_subset_indices)
-        validation_set = Subset(validation_set, val_subset_indices)
+        val_indices = torch.nonzero(val_subset_indices.bool(), as_tuple=True)[
+            0
+        ].tolist()
+        validation_set = Subset(validation_set, val_indices)
     if train_subset_indices is not None:
         loaders = {
             "train": DataLoader(

--- a/src/evaluation/SVC_MIA.py
+++ b/src/evaluation/SVC_MIA.py
@@ -11,15 +11,18 @@ def entropy(p, dim=-1, keepdim=False):
 
 
 def m_entropy(p, labels, dim=-1, keepdim=False):
-    log_prob = torch.where(p > 0, p.log(), torch.tensor(1e-30).to(p.device).log())
+    eps = p.new_tensor(1e-30)
+    labels = labels.to(device=p.device, dtype=torch.long)
+    log_prob = torch.where(p > 0, p.log(), eps.log())
     reverse_prob = 1 - p
     log_reverse_prob = torch.where(
-        p > 0, p.log(), torch.tensor(1e-30).to(p.device).log()
+        reverse_prob > 0, reverse_prob.log(), eps.log()
     )
     modified_probs = p.clone()
-    modified_probs[:, labels] = reverse_prob[:, labels]
+    rows = torch.arange(p.size(0), device=p.device)
+    modified_probs[rows, labels] = reverse_prob[rows, labels]
     modified_log_probs = log_reverse_prob.clone()
-    modified_log_probs[:, labels] = log_prob[:, labels]
+    modified_log_probs[rows, labels] = log_prob[rows, labels]
     return -torch.sum(modified_probs * modified_log_probs, dim=dim, keepdim=keepdim)
 
 

--- a/src/pruner/utils.py
+++ b/src/pruner/utils.py
@@ -129,14 +129,14 @@ def check_sparsity(model):
             sum_list = sum_list + float(m.weight.nelement())
             zero_sum = zero_sum + float(torch.sum(m.weight == 0))
 
-    if zero_sum:
-        remain_weight_ratie = 100 * (1 - zero_sum / sum_list)
-        print("* remain weight ratio = ", 100 * (1 - zero_sum / sum_list), "%")
-    else:
+    if sum_list == 0:
         print("no weight for calculating sparsity")
-        remain_weight_ratie = None
+        remain_weight_ratio = None
+    else:
+        remain_weight_ratio = 100 * (1 - zero_sum / sum_list)
+        print("* remain weight ratio = ", remain_weight_ratio, "%")
 
-    return remain_weight_ratie
+    return remain_weight_ratio
 
 
 def count_sparsity(model):
@@ -165,14 +165,14 @@ def check_sparsity_dict(state_dict):
             sum_list += float(state_dict[key].nelement())
             zero_sum += float(torch.sum(state_dict[key] == 0))
 
-    if zero_sum:
-        remain_weight_ratie = 100 * (1 - zero_sum / sum_list)
-        print("* remain weight ratio = ", 100 * (1 - zero_sum / sum_list), "%")
-    else:
+    if sum_list == 0:
         print("no weight for calculating sparsity")
-        remain_weight_ratie = None
+        remain_weight_ratio = None
+    else:
+        remain_weight_ratio = 100 * (1 - zero_sum / sum_list)
+        print("* remain weight ratio = ", remain_weight_ratio, "%")
 
-    return remain_weight_ratie
+    return remain_weight_ratio
 
 
 def fetch_data(dataloader, num_classes, samples_per_class):


### PR DESCRIPTION
## Summary
- fix replacement/index marking helpers for datasets with targets, labels, imgs, or data attributes
- convert ImageNet subset masks to one-dimensional index lists before creating Subset objects
- correct SVC MIA modified entropy indexing and reverse-probability log computation
- report dense model sparsity as 100% remaining instead of no weight

## Tests
- python -m compileall -q main.py src
- git diff --check
- focused Python checks for replace_indexes, m_entropy, and sparsity helpers