### PR TITLE
Fix SwinT defaults for CIFAR inputs

### DIFF
--- a/src/models/swin.py
+++ b/src/models/swin.py
@@ -360,7 +360,23 @@ class SwinTransformer(nn.Module):
         return self.mlp_head(x)
 
 
+_CIFAR_SWINT_DEFAULTS = {
+    "window_size": 4,
+    "downscaling_factors": (2, 2, 2, 1),
+}
+
+
+def _resolve_swin_t_kwargs(kwargs):
+    kwargs = dict(kwargs)
+    imagenet = kwargs.pop("imagenet", False)
+    if not imagenet:
+        for key, value in _CIFAR_SWINT_DEFAULTS.items():
+            kwargs.setdefault(key, value)
+    return kwargs
+
+
 def swin_t(hidden_dim=96, layers=(2, 2, 6, 2), heads=(3, 6, 12, 24), **kwargs):
+    kwargs = _resolve_swin_t_kwargs(kwargs)
     return SwinTransformer(hidden_dim=hidden_dim, layers=layers, heads=heads, **kwargs)
 
 


### PR DESCRIPTION
## Summary
- default non-ImageNet `swin_t` to the CIFAR-compatible window/downscaling setup
- keep `imagenet=True` on the original ImageNet Swin-T defaults

Fixes #12.

## Verification
- `python -m compileall src/models/swin.py`
- direct forward checks for default CIFAR 32x32, explicit CIFAR 32x32, CIFAR-100 32x32, TinyImageNet 64x64, and ImageNet 224x224 cases
- `git diff --check`