### PR TITLE
Add downstream transfer learning pipeline

### DIFF
--- a/.codex/skills/unlearn-sparse-repro/SKILL.md
+++ b/.codex/skills/unlearn-sparse-repro/SKILL.md
@@ -12,6 +12,7 @@ description: Build and verify reproduction plans for the Unlearn-Sparse paper "M
    - `python main.py train --help`
    - `python main.py unlearn --help`
    - `python main.py backdoor --help`
+   - `python main.py transfer --help`
    - `git status --short --branch`
 2. Read `references/repro-matrix.md` when mapping paper results to commands or when the user asks for "all experiments".
 3. Use `scripts/generate_repro_commands.py` to create a runnable bash plan, then review the generated commands before running long jobs.
@@ -35,6 +36,7 @@ Available suites:
 - `appendix`: extra dataset/model sweeps that are exposed by the current CLI.
 - `backdoor`: Trojan cleanse commands across sparsity levels.
 - `imagenet`: ImageNet unlearning command skeletons with required label/HuggingFace prerequisites called out.
+- `transfer`: downstream OxfordPets/SUN397 linear-probing commands from ImageNet checkpoints.
 - `all`: concatenate all reproducible suites.
 
 The generator only emits commands; it does not submit jobs. If the user asks to run them, ask for the GPU budget or choose a small smoke subset.
@@ -66,4 +68,4 @@ If a run is resumed, verify that the saved `evaluation_result` is not silently s
 
 ## Repro Limits
 
-Be explicit about coverage. The current repo directly covers train/prune, unlearn, MIA evaluation, and backdoor cleanse. The paper's ImageNet transfer-learning application requires downstream linear-probing/FFCV pieces that are not exposed as a first-class CLI in this checkout; document the missing step instead of inventing a command.
+Be explicit about coverage. The current repo directly covers train/prune, unlearn, MIA evaluation, backdoor cleanse, and downstream transfer through `main.py transfer`. The transfer CLI implements the paper's linear-probing shape, but exact Table 4 reproduction still depends on using the same ImageNet class-removal checkpoints and downstream split files; the repo uses torchvision loaders instead of FFCV.

--- a/.codex/skills/unlearn-sparse-repro/references/repro-matrix.md
+++ b/.codex/skills/unlearn-sparse-repro/references/repro-matrix.md
@@ -11,6 +11,7 @@ The paper evaluates "prune first, then unlearn" across class-wise forgetting, ra
 - `python main.py train`: baseline training plus iterative pruning profiles `imp`, `ls`, `sam`, `vit`, `synflow`.
 - `python main.py unlearn`: retrain/approximate unlearning and automatic accuracy/MIA evaluation.
 - `python main.py backdoor`: backdoor poisoning and cleanse flow.
+- `python main.py transfer`: downstream transfer learning from an ImageNet checkpoint.
 
 The paper metrics map to repo outputs as follows:
 
@@ -120,11 +121,26 @@ python -u main.py unlearn --dataset imagenet --imagenet_arch --arch resnet18 \
 
 ## Transfer Learning Result
 
-The paper evaluates removing ImageNet classes and downstream linear probing on SUN397 and OxfordPets, with FFCV used for acceleration. The current repo does not provide a complete transfer-learning CLI for this table. To reproduce it, state the missing pieces:
+The paper evaluates removing ImageNet classes and downstream linear probing on SUN397 and OxfordPets, with FFCV used for acceleration. The repo now exposes this as `main.py transfer`.
 
-- An ImageNet source-model unlearning stage.
-- Downstream dataset loaders for SUN397 and OxfordPets.
-- A linear-probing script that freezes the feature extractor and trains only the classification head.
-- Runtime logging consistent with the paper's comparison.
+Default command shape:
 
-Do not claim this result is fully reproducible from `main.py` alone.
+```bash
+python -u main.py transfer --arch resnet18 --imagenet_arch \
+  --source_checkpoint ./runs/imagenet_resnet18/forget_100/FT_prunecheckpoint.pth.tar \
+  --target_dataset oxfordpets --target_data ./data \
+  --save_dir ./runs/transfer/oxfordpets_forget_100 \
+  --transfer_method lp --transfer_epochs 200 --transfer_lr 0.0001 \
+  --transfer_optimizer Adam --transfer_resolution 224 \
+  --batch_size 128 --transfer_test_batch_size 1024
+```
+
+Transfer options:
+
+- `--transfer_method lp`: freezes the feature extractor and trains only the classifier head. This is the paper-aligned default.
+- `--transfer_method ff`: full finetuning, available for ablations but not the Table 4 default.
+- `--target_dataset oxfordpets`: uses torchvision Oxford-IIIT Pet `trainval`/`test`.
+- `--target_dataset sun397`: uses torchvision SUN397 and a deterministic stratified fallback split.
+- `--transfer_split_file <json>`: preferred for paper-equivalent SUN397/OxfordPets CoOp-style splits. JSON entries can use `impath`, `image`, or `path` plus `label`; tuple/list entries can use `[path, label, ...]`.
+
+Exact Table 4 reproduction still requires matching the paper's ImageNet source/unlearned checkpoints for 100/200/300 removed classes and, for strict downstream comparability, the same split assets used in the paper. The current repo uses torchvision loaders instead of FFCV, so report runtime separately.

--- a/.codex/skills/unlearn-sparse-repro/scripts/generate_repro_commands.py
+++ b/.codex/skills/unlearn-sparse-repro/scripts/generate_repro_commands.py
@@ -7,6 +7,7 @@ import argparse
 import shlex
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 
 UNLEARN_METHODS = {
@@ -317,6 +318,116 @@ def emit_imagenet(args) -> list[str]:
     return lines
 
 
+def transfer_cmd(
+    args,
+    *,
+    seed: int,
+    target_dataset: str,
+    source_checkpoint: Path,
+    save_dir: Path,
+    split_file: Optional[str] = None,
+) -> list[str]:
+    cmd = [
+        "python",
+        "-u",
+        "main.py",
+        "transfer",
+        "--arch",
+        "resnet18",
+        "--imagenet_arch",
+        "--source_checkpoint",
+        str(source_checkpoint),
+        "--source_num_classes",
+        "1000",
+        "--target_dataset",
+        target_dataset,
+        "--target_data",
+        args.data,
+        "--save_dir",
+        str(save_dir),
+        "--transfer_method",
+        args.transfer_method,
+        "--transfer_epochs",
+        str(args.transfer_epochs),
+        "--transfer_lr",
+        str(args.transfer_lr),
+        "--transfer_optimizer",
+        "Adam",
+        "--transfer_resolution",
+        "224",
+        "--batch_size",
+        str(args.transfer_batch_size),
+        "--transfer_test_batch_size",
+        str(args.transfer_test_batch_size),
+        "--workers",
+        str(args.workers),
+        "--seed",
+        str(seed),
+    ]
+    if split_file:
+        cmd.extend(["--transfer_split_file", split_file])
+    return cmd
+
+
+def emit_transfer(args) -> list[str]:
+    lines = [
+        "# Transfer-learning commands for the paper's ImageNet -> OxfordPets/SUN397 setup.",
+        "# Run ImageNet source/unlearning first, then point --source_checkpoint to the resulting checkpoint.",
+        "# SUN397 paper-equivalent reproduction should use a CoOp-style split via --sun397-split.",
+    ]
+    targets = [
+        ("oxfordpets", args.oxfordpets_split or None),
+        ("sun397", args.sun397_split or None),
+    ]
+    for seed in args.seeds:
+        base_dir = Path(args.runs) / "transfer" / f"seed_{seed}"
+        source_checkpoint = (
+            Path(args.runs)
+            / "imagenet_resnet18"
+            / f"seed_{seed}"
+            / "0model_SA_best.pth.tar"
+        )
+        for target_dataset, split_file in targets:
+            save_dir = base_dir / target_dataset / "source"
+            lines.append(
+                shell_join(
+                    transfer_cmd(
+                        args,
+                        seed=seed,
+                        target_dataset=target_dataset,
+                        source_checkpoint=source_checkpoint,
+                        save_dir=save_dir,
+                        split_file=split_file,
+                    )
+                )
+            )
+
+        for forget_count in ["100", "200", "300"]:
+            source_checkpoint = (
+                Path(args.runs)
+                / "imagenet_resnet18"
+                / f"seed_{seed}"
+                / f"forget_{forget_count}"
+                / "FT_prunecheckpoint.pth.tar"
+            )
+            for target_dataset, split_file in targets:
+                save_dir = base_dir / target_dataset / f"forget_{forget_count}"
+                lines.append(
+                    shell_join(
+                        transfer_cmd(
+                            args,
+                            seed=seed,
+                            target_dataset=target_dataset,
+                            source_checkpoint=source_checkpoint,
+                            save_dir=save_dir,
+                            split_file=split_file,
+                        )
+                    )
+                )
+    lines.append("")
+    return lines
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -327,6 +438,7 @@ def main() -> None:
             "appendix",
             "backdoor",
             "imagenet",
+            "transfer",
             "all",
         ],
         default="core",
@@ -337,6 +449,13 @@ def main() -> None:
     parser.add_argument("--seeds", type=parse_seeds, default=parse_seeds("1"))
     parser.add_argument("--epochs", type=int, default=182)
     parser.add_argument("--rewind-epoch", type=int, default=8)
+    parser.add_argument("--transfer-method", choices=["lp", "ff"], default="lp")
+    parser.add_argument("--transfer-epochs", type=int, default=200)
+    parser.add_argument("--transfer-lr", type=float, default=1e-4)
+    parser.add_argument("--transfer-batch-size", type=int, default=128)
+    parser.add_argument("--transfer-test-batch-size", type=int, default=1024)
+    parser.add_argument("--oxfordpets-split", default="")
+    parser.add_argument("--sun397-split", default="")
     args = parser.parse_args()
 
     emitters = {
@@ -345,6 +464,7 @@ def main() -> None:
         "appendix": emit_appendix,
         "backdoor": emit_backdoor,
         "imagenet": emit_imagenet,
+        "transfer": emit_transfer,
     }
     suites = list(emitters) if args.suite == "all" else [args.suite]
 

--- a/README.MD
+++ b/README.MD
@@ -38,6 +38,7 @@ conda env create -f environment.yml
 1. Run ```train``` first to produce a sparse checkpoint.
 2. Run ```unlearn``` with that checkpoint (via ```--mask```) to remove target-data influence.
 3. Check accuracy + MIA results, and optionally run ```backdoor``` for security-focused evaluation.
+4. Use ```transfer``` to run downstream linear probing from an ImageNet source or unlearned checkpoint.
 
 ## Commands
 
@@ -159,7 +160,21 @@ python -u main.py backdoor \
 ```
 This command evaluates unlearning in a security setting by first simulating poisoned trigger behavior and then applying unlearning to clean it, with the key readout being whether attack success drops while clean accuracy remains usable.
 
-### 4) Resume interrupted runs
+### 4) Transfer learning (single entry: `transfer`)
+
+```bash
+python -u main.py transfer \
+  --arch resnet18 --imagenet_arch \
+  --source_checkpoint ./runs/imagenet_resnet18/FT_prunecheckpoint.pth.tar \
+  --target_dataset oxfordpets --target_data ./data \
+  --save_dir ./runs/transfer/oxfordpets_lp \
+  --transfer_method lp --transfer_epochs 200 --transfer_lr 0.0001 \
+  --transfer_optimizer Adam --transfer_resolution 224 \
+  --batch_size 128 --transfer_test_batch_size 1024
+```
+This command evaluates the paper's transfer-learning setup: load an ImageNet source or unlearned checkpoint, replace the classifier for the downstream dataset, freeze the feature extractor under ```--transfer_method lp```, and train only the new head. Supported downstream loaders are ```oxfordpets```, ```sun397```, ImageFolder train/test paths, or a CoOp-style JSON split via ```--transfer_split_file```. For strict SUN397 reproduction, pass the same split file used by the paper; otherwise the torchvision SUN397 path uses a deterministic stratified fallback split.
+
+### 5) Resume interrupted runs
 
 ```bash
 # resume pruning
@@ -179,6 +194,7 @@ The source code is organized as follows:
     - `train` -> `src/pipelines/train_pipeline.py`
     - `unlearn` -> `src/pipelines/forget_pipeline.py`
     - `backdoor` -> `src/pipelines/backdoor_pipeline.py`
+    - `transfer` -> `src/pipelines/transfer_pipeline.py`
 
 - **Core CLI / Utilities**
   - `src/core/arg_parser.py`: Shared argument definitions used by all workflows.
@@ -188,6 +204,7 @@ The source code is organized as follows:
   - `src/pipelines/train_pipeline.py`: Training + pruning implementations (IMP/LS/SAM/ViT profiles and SynFlow).
   - `src/pipelines/forget_pipeline.py`: Unlearning pipeline; loads sparse masks, runs unlearn methods, and evaluates accuracy/MIA.
   - `src/pipelines/backdoor_pipeline.py`: Backdoor cleansing pipeline; builds poisoned data loaders and applies unlearning.
+  - `src/pipelines/transfer_pipeline.py`: Downstream linear probing/full finetuning from ImageNet source or unlearned checkpoints.
 
 - **Training / Optimization / Pruning**
   - `src/trainer/`: Train/validate loops (standard SGD loop and SAM training loop).

--- a/main.py
+++ b/main.py
@@ -11,7 +11,8 @@ def build_cli():
             "  train    Train + iterative pruning (replaces main_imp.py/main_ls.py/main_sam.py/main_vit.py/main_synflow.py)\n"
             "  prune    Legacy alias of 'train'\n"
             "  unlearn  Run machine unlearning (replaces main_forget.py/main_forget_imagenet.py)\n"
-            "  backdoor Run backdoor cleanse experiment (replaces main_backdoor.py)"
+            "  backdoor Run backdoor cleanse experiment (replaces main_backdoor.py)\n"
+            "  transfer Run downstream transfer learning / linear probing"
         ),
         formatter_class=argparse.RawTextHelpFormatter,
     )
@@ -19,18 +20,18 @@ def build_cli():
 
     def _add_train_profile_arg(subparser):
         subparser.add_argument(
-        "--profile",
-        default="imp",
-        choices=["imp", "ls", "sam", "vit", "synflow"],
-        help=(
-            "Training profile (with pruning strategy):\n"
-            "  imp -> standard IMP/OMP training pipeline\n"
-            "  ls  -> label-smoothing variant\n"
-            "  sam -> SAM optimizer variant\n"
-            "  vit -> ViT-style optimizer/scheduler variant\n"
-            "  synflow -> SynFlow pruning pipeline"
-        ),
-    )
+            "--profile",
+            default="imp",
+            choices=["imp", "ls", "sam", "vit", "synflow"],
+            help=(
+                "Training profile (with pruning strategy):\n"
+                "  imp -> standard IMP/OMP training pipeline\n"
+                "  ls  -> label-smoothing variant\n"
+                "  sam -> SAM optimizer variant\n"
+                "  vit -> ViT-style optimizer/scheduler variant\n"
+                "  synflow -> SynFlow pruning pipeline"
+            ),
+        )
 
     train = subparsers.add_parser("train", help="Train + iterative pruning")
     _add_train_profile_arg(train)
@@ -51,6 +52,9 @@ def build_cli():
 
     subparsers.add_parser(
         "backdoor", help="Run backdoor cleanse pipeline (legacy: main_backdoor.py)"
+    )
+    subparsers.add_parser(
+        "transfer", help="Run downstream transfer learning", add_help=False
     )
     return parser
 
@@ -73,6 +77,12 @@ def main():
         from src.pipelines.backdoor_pipeline import run_backdoor
 
         run_backdoor(run_args)
+        return
+
+    if cli_args.command == "transfer":
+        from src.pipelines.transfer_pipeline import run_transfer
+
+        run_transfer(run_args)
         return
 
     from src.pipelines.forget_pipeline import run_forget

--- a/src/core/arg_parser.py
+++ b/src/core/arg_parser.py
@@ -146,4 +146,106 @@ def parse_args(argv=None):
         default=4,
         help="The size of trigger of backdoor attack",
     )
+    ##################################### Transfer learning setting #####################################
+    parser.add_argument(
+        "--source_checkpoint",
+        type=str,
+        default=None,
+        help="ImageNet source/unlearned checkpoint for transfer learning",
+    )
+    parser.add_argument(
+        "--source_num_classes",
+        type=int,
+        default=1000,
+        help="Number of classes in the source checkpoint head",
+    )
+    parser.add_argument(
+        "--target_dataset",
+        type=str,
+        default="oxfordpets",
+        help="Downstream transfer dataset: oxfordpets, sun397, or imagefolder",
+    )
+    parser.add_argument(
+        "--target_data",
+        type=str,
+        default="./data",
+        help="Root directory for downstream transfer datasets",
+    )
+    parser.add_argument(
+        "--target_train_path",
+        type=str,
+        default=None,
+        help="Optional ImageFolder train path for transfer learning",
+    )
+    parser.add_argument(
+        "--target_test_path",
+        type=str,
+        default=None,
+        help="Optional ImageFolder test path for transfer learning",
+    )
+    parser.add_argument(
+        "--transfer_split_file",
+        type=str,
+        default=None,
+        help="Optional CoOp-style JSON split file with train/val/test entries",
+    )
+    parser.add_argument(
+        "--transfer_include_val",
+        action="store_true",
+        help="Include val entries from --transfer_split_file in transfer training",
+    )
+    parser.add_argument(
+        "--transfer_train_ratio",
+        type=float,
+        default=0.8,
+        help="Deterministic train ratio for datasets without official train/test split",
+    )
+    parser.add_argument(
+        "--transfer_method",
+        type=str,
+        default="lp",
+        choices=["lp", "ff"],
+        help="Transfer method: lp freezes the feature extractor, ff full-finetunes",
+    )
+    parser.add_argument(
+        "--transfer_epochs", type=int, default=200, help="Transfer training epochs"
+    )
+    parser.add_argument(
+        "--transfer_lr", type=float, default=1e-4, help="Transfer optimizer learning rate"
+    )
+    parser.add_argument(
+        "--transfer_weight_decay",
+        type=float,
+        default=0.0,
+        help="Transfer optimizer weight decay",
+    )
+    parser.add_argument(
+        "--transfer_optimizer",
+        type=str,
+        default="Adam",
+        choices=["Adam", "SGD"],
+        help="Transfer optimizer",
+    )
+    parser.add_argument(
+        "--transfer_resolution",
+        type=int,
+        default=224,
+        help="Input resolution for downstream transfer learning",
+    )
+    parser.add_argument(
+        "--transfer_test_batch_size",
+        type=int,
+        default=1024,
+        help="Transfer evaluation batch size",
+    )
+    parser.add_argument(
+        "--transfer_download",
+        action="store_true",
+        help="Download torchvision downstream datasets when missing",
+    )
+    parser.add_argument(
+        "--transfer_eval_only",
+        action="store_true",
+        help="Only evaluate a transfer checkpoint from --checkpoint",
+    )
     return parser.parse_args(argv)

--- a/src/pipelines/transfer_pipeline.py
+++ b/src/pipelines/transfer_pipeline.py
@@ -1,0 +1,444 @@
+import json
+import os
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+from PIL import Image
+from torch.utils.data import DataLoader, Dataset, Subset
+from torchvision import datasets, transforms
+
+import src.pruner as pruner
+from src.core import utils
+from src.models import model_dict
+
+
+class JsonSplitDataset(Dataset):
+    def __init__(self, root, entries, transform=None):
+        self.root = Path(root)
+        self.entries = entries
+        self.transform = transform
+
+    def __len__(self):
+        return len(self.entries)
+
+    def __getitem__(self, index):
+        path, label = self.entries[index]
+        image_path = Path(path)
+        if not image_path.is_absolute():
+            image_path = self.root / image_path
+        image = Image.open(image_path).convert("RGB")
+        if self.transform is not None:
+            image = self.transform(image)
+        return image, int(label)
+
+
+def _setup_device(args):
+    if torch.cuda.is_available():
+        torch.cuda.set_device(int(args.gpu))
+        return torch.device(f"cuda:{int(args.gpu)}")
+    return torch.device("cpu")
+
+
+def _transfer_transform(args, train):
+    if train and args.transfer_method == "ff":
+        return transforms.Compose(
+            [
+                transforms.RandomResizedCrop(args.transfer_resolution),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+            ]
+        )
+    resize = int(round(args.transfer_resolution / 0.875))
+    return transforms.Compose(
+        [
+            transforms.Resize(resize),
+            transforms.CenterCrop(args.transfer_resolution),
+            transforms.ToTensor(),
+        ]
+    )
+
+
+def _parse_split_entry(entry):
+    if isinstance(entry, dict):
+        path = entry.get("impath") or entry.get("image") or entry.get("path")
+        label = entry.get("label")
+    else:
+        path, label = entry[0], entry[1]
+    if path is None or label is None:
+        raise ValueError(f"Unsupported split entry: {entry}")
+    return path, int(label)
+
+
+def _load_json_split(args, train_transform, test_transform):
+    with open(args.transfer_split_file, "r") as f:
+        split = json.load(f)
+    train_entries = list(split.get("train", []))
+    if args.transfer_include_val:
+        train_entries.extend(split.get("val", []))
+    test_entries = split.get("test", [])
+    if not train_entries or not test_entries:
+        raise ValueError("Split file must contain non-empty train and test entries")
+
+    train_entries = [_parse_split_entry(entry) for entry in train_entries]
+    test_entries = [_parse_split_entry(entry) for entry in test_entries]
+    num_classes = max(label for _, label in train_entries + test_entries) + 1
+    train_set = JsonSplitDataset(args.target_data, train_entries, train_transform)
+    test_set = JsonSplitDataset(args.target_data, test_entries, test_transform)
+    return train_set, test_set, num_classes
+
+
+def _dataset_labels(dataset):
+    for attr in ("targets", "labels", "_labels"):
+        if hasattr(dataset, attr):
+            return list(getattr(dataset, attr))
+    if hasattr(dataset, "samples"):
+        return [label for _, label in dataset.samples]
+    raise AttributeError(f"Cannot find labels for {type(dataset).__name__}")
+
+
+def _stratified_split(dataset, ratio, seed):
+    labels = {}
+    for index, label in enumerate(_dataset_labels(dataset)):
+        labels.setdefault(int(label), []).append(index)
+
+    rng = np.random.RandomState(seed)
+    train_indices = []
+    test_indices = []
+    for indices in labels.values():
+        rng.shuffle(indices)
+        split = max(1, int(round(len(indices) * ratio)))
+        split = min(split, len(indices) - 1) if len(indices) > 1 else len(indices)
+        train_indices.extend(indices[:split])
+        test_indices.extend(indices[split:])
+    return Subset(dataset, train_indices), Subset(dataset, test_indices)
+
+
+def _ensure_transfer_save_dir(args):
+    if args.save_dir is None:
+        args.save_dir = os.path.join(
+            "./runs",
+            "transfer",
+            f"{args.target_dataset}_{args.arch}_{args.transfer_method}",
+        )
+
+
+def _build_transfer_datasets(args):
+    train_transform = _transfer_transform(args, train=True)
+    test_transform = _transfer_transform(args, train=False)
+
+    if args.transfer_split_file is not None:
+        return _load_json_split(args, train_transform, test_transform)
+
+    if args.target_train_path and args.target_test_path:
+        train_set = datasets.ImageFolder(args.target_train_path, transform=train_transform)
+        test_set = datasets.ImageFolder(args.target_test_path, transform=test_transform)
+        if train_set.class_to_idx != test_set.class_to_idx:
+            raise ValueError("ImageFolder train/test class_to_idx mappings must match")
+        return train_set, test_set, len(train_set.classes)
+
+    target = args.target_dataset.lower()
+    if target in {"oxfordpets", "oxford_iiit_pet", "pets"}:
+        train_set = datasets.OxfordIIITPet(
+            args.target_data,
+            split="trainval",
+            target_types="category",
+            transform=train_transform,
+            download=args.transfer_download,
+        )
+        test_set = datasets.OxfordIIITPet(
+            args.target_data,
+            split="test",
+            target_types="category",
+            transform=test_transform,
+            download=args.transfer_download,
+        )
+        return train_set, test_set, 37
+
+    if target == "sun397":
+        full_train = datasets.SUN397(
+            args.target_data, transform=train_transform, download=args.transfer_download
+        )
+        full_test = datasets.SUN397(
+            args.target_data, transform=test_transform, download=False
+        )
+        print(
+            "SUN397 has no train/test split in torchvision; using a deterministic "
+            f"{args.transfer_train_ratio:.2f} stratified split. "
+            "Pass --transfer_split_file for CoOp-style splits."
+        )
+        train_set, _ = _stratified_split(full_train, args.transfer_train_ratio, args.seed)
+        _, test_set = _stratified_split(full_test, args.transfer_train_ratio, args.seed)
+        return train_set, test_set, 397
+
+    raise ValueError(
+        "Unsupported target dataset. Use oxfordpets, sun397, imagefolder paths, "
+        "or --transfer_split_file."
+    )
+
+
+def _clean_state_dict(state_dict):
+    return {
+        key.replace("module.", "", 1) if key.startswith("module.") else key: value
+        for key, value in state_dict.items()
+    }
+
+
+def _extract_state_dict(checkpoint):
+    if isinstance(checkpoint, dict):
+        if "state_dict" in checkpoint:
+            return checkpoint["state_dict"]
+        if "state_dicts" in checkpoint and "network" in checkpoint["state_dicts"]:
+            return checkpoint["state_dicts"]["network"]
+    return checkpoint
+
+
+def _replace_classifier(model, num_classes):
+    if hasattr(model, "fc") and isinstance(model.fc, nn.Linear):
+        in_features = model.fc.in_features
+        model.fc = nn.Linear(in_features, num_classes)
+        return model.fc
+
+    if hasattr(model, "classifier"):
+        classifier = model.classifier
+        if isinstance(classifier, nn.Linear):
+            in_features = classifier.in_features
+            model.classifier = nn.Linear(in_features, num_classes)
+            return model.classifier
+        if isinstance(classifier, nn.Sequential):
+            modules = list(classifier.children())
+            for index in range(len(modules) - 1, -1, -1):
+                if isinstance(modules[index], nn.Linear):
+                    in_features = modules[index].in_features
+                    modules[index] = nn.Linear(in_features, num_classes)
+                    model.classifier = nn.Sequential(*modules)
+                    return model.classifier[index]
+
+    if hasattr(model, "mlp_head") and isinstance(model.mlp_head, nn.Sequential):
+        modules = list(model.mlp_head.children())
+        for index in range(len(modules) - 1, -1, -1):
+            if isinstance(modules[index], nn.Linear):
+                in_features = modules[index].in_features
+                modules[index] = nn.Linear(in_features, num_classes)
+                model.mlp_head = nn.Sequential(*modules)
+                return model.mlp_head[index]
+
+    raise ValueError("Could not find a replaceable classifier head on the model")
+
+
+def _build_model(args, num_classes, device):
+    if args.source_checkpoint is None and not args.transfer_eval_only:
+        raise ValueError("--source_checkpoint is required for transfer learning")
+
+    model = model_dict[args.arch](
+        num_classes=args.source_num_classes, imagenet=True
+    )
+    model.normalize = utils.NormalizeByChannelMeanStd(
+        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+    )
+
+    if args.source_checkpoint is not None:
+        checkpoint = torch.load(args.source_checkpoint, map_location=device)
+        state_dict = _clean_state_dict(_extract_state_dict(checkpoint))
+        current_mask = pruner.extract_mask(state_dict)
+        if current_mask:
+            pruner.prune_model_custom(model, current_mask)
+            pruner.check_sparsity(model)
+        model.load_state_dict(state_dict, strict=False)
+
+    head = _replace_classifier(model, num_classes)
+    model.to(device)
+
+    if args.transfer_method == "lp":
+        model.requires_grad_(False)
+        head.requires_grad_(True)
+    return model
+
+
+def _build_optimizer(args, model):
+    params = [param for param in model.parameters() if param.requires_grad]
+    if not params:
+        raise ValueError("No trainable parameters found for transfer learning")
+    if args.transfer_optimizer == "SGD":
+        return torch.optim.SGD(
+            params,
+            lr=args.transfer_lr,
+            momentum=args.momentum,
+            weight_decay=args.transfer_weight_decay,
+        )
+    return torch.optim.Adam(
+        params, lr=args.transfer_lr, weight_decay=args.transfer_weight_decay
+    )
+
+
+def _accuracy(output, target, topk=(1,)):
+    maxk = min(max(topk), output.size(1))
+    batch_size = target.size(0)
+    _, pred = output.topk(maxk, 1, True, True)
+    pred = pred.t()
+    correct = pred.eq(target.view(1, -1).expand_as(pred))
+
+    result = []
+    for k in topk:
+        k = min(k, output.size(1))
+        correct_k = correct[:k].reshape(-1).float().sum(0)
+        result.append(correct_k.mul_(100.0 / batch_size))
+    return result
+
+
+def _run_epoch(loader, model, criterion, optimizer, scheduler, args, device, epoch):
+    if args.transfer_method == "lp":
+        model.eval()
+    else:
+        model.train()
+
+    losses = utils.AverageMeter()
+    top1 = utils.AverageMeter()
+    start = time.time()
+    for step, (image, target) in enumerate(loader):
+        image = image.to(device)
+        target = target.to(device)
+
+        output = model(image)
+        loss = criterion(output, target)
+
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        scheduler.step()
+
+        acc1 = _accuracy(output.float(), target, topk=(1,))[0]
+        losses.update(loss.item(), image.size(0))
+        top1.update(acc1.item(), image.size(0))
+
+        if (step + 1) % args.print_freq == 0:
+            print(
+                "Transfer epoch: [{0}][{1}/{2}]\t"
+                "Loss {loss.val:.4f} ({loss.avg:.4f})\t"
+                "Accuracy {top1.val:.3f} ({top1.avg:.3f})\t"
+                "Time {3:.2f}".format(
+                    epoch, step, len(loader), time.time() - start, loss=losses, top1=top1
+                )
+            )
+            start = time.time()
+    return {"loss": losses.avg, "top1": top1.avg}
+
+
+def _evaluate(loader, model, criterion, device):
+    model.eval()
+    losses = utils.AverageMeter()
+    top1 = utils.AverageMeter()
+    top5 = utils.AverageMeter()
+    with torch.no_grad():
+        for image, target in loader:
+            image = image.to(device)
+            target = target.to(device)
+            output = model(image)
+            loss = criterion(output, target)
+            acc1, acc5 = _accuracy(output.float(), target, topk=(1, 5))
+            losses.update(loss.item(), image.size(0))
+            top1.update(acc1.item(), image.size(0))
+            top5.update(acc5.item(), image.size(0))
+    return {"loss": losses.avg, "top1": top1.avg, "top5": top5.avg}
+
+
+def _save_transfer_checkpoint(path, model, optimizer, scheduler, epoch, best_acc, result):
+    os.makedirs(path, exist_ok=True)
+    state = {
+        "state_dict": model.state_dict(),
+        "optimizer": optimizer.state_dict() if optimizer is not None else None,
+        "scheduler": scheduler.state_dict() if scheduler is not None else None,
+        "epoch": epoch,
+        "best_acc": best_acc,
+        "result": result,
+    }
+    torch.save(state, os.path.join(path, "transfer_checkpoint.pth.tar"))
+    torch.save(result, os.path.join(path, "transfer_result.pth.tar"))
+
+
+def run_transfer(args):
+    device = _setup_device(args)
+    _ensure_transfer_save_dir(args)
+    os.makedirs(args.save_dir, exist_ok=True)
+    if args.seed:
+        utils.setup_seed(args.seed)
+
+    train_set, test_set, num_classes = _build_transfer_datasets(args)
+    train_loader = DataLoader(
+        train_set,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.workers,
+        pin_memory=torch.cuda.is_available(),
+    )
+    test_loader = DataLoader(
+        test_set,
+        batch_size=args.transfer_test_batch_size,
+        shuffle=False,
+        num_workers=args.workers,
+        pin_memory=torch.cuda.is_available(),
+    )
+
+    target_name = args.target_dataset
+    if args.target_train_path and args.target_test_path:
+        target_name = "imagefolder"
+    if args.transfer_split_file is not None:
+        target_name = f"split:{args.transfer_split_file}"
+
+    print(
+        "Transfer dataset: "
+        f"{target_name}, train={len(train_set)}, test={len(test_set)}, "
+        f"classes={num_classes}"
+    )
+
+    model = _build_model(args, num_classes, device)
+    criterion = nn.CrossEntropyLoss()
+
+    result = {"train": [], "test": []}
+    best_acc = 0
+
+    if args.transfer_eval_only:
+        if args.checkpoint is None:
+            raise ValueError("--checkpoint is required with --transfer_eval_only")
+        checkpoint = torch.load(args.checkpoint, map_location=device)
+        state_dict = _clean_state_dict(_extract_state_dict(checkpoint))
+        current_mask = pruner.extract_mask(state_dict)
+        if current_mask:
+            pruner.prune_model_custom(model, current_mask)
+        model.load_state_dict(state_dict, strict=False)
+        test_stats = _evaluate(test_loader, model, criterion, device)
+        result["test"].append(test_stats)
+        print(f"transfer test acc: {test_stats['top1']:.3f}")
+        _save_transfer_checkpoint(args.save_dir, model, None, None, 0, test_stats["top1"], result)
+        return
+
+    optimizer = _build_optimizer(args, model)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        optimizer, T_max=max(1, args.transfer_epochs * len(train_loader))
+    )
+
+    for epoch in range(args.transfer_epochs):
+        start = time.time()
+        train_stats = _run_epoch(
+            train_loader, model, criterion, optimizer, scheduler, args, device, epoch
+        )
+        test_stats = _evaluate(test_loader, model, criterion, device)
+        result["train"].append(train_stats)
+        result["test"].append(test_stats)
+        best_acc = max(best_acc, test_stats["top1"])
+        print(
+            "Transfer epoch #{}, train_acc={:.3f}, test_acc={:.3f}, "
+            "test_top5={:.3f}, best_acc={:.3f}, duration={:.2f}".format(
+                epoch,
+                train_stats["top1"],
+                test_stats["top1"],
+                test_stats["top5"],
+                best_acc,
+                time.time() - start,
+            )
+        )
+        _save_transfer_checkpoint(
+            args.save_dir, model, optimizer, scheduler, epoch + 1, best_acc, result
+        )


### PR DESCRIPTION
## Summary
- add a transfer subcommand for downstream ImageNet-to-OxfordPets/SUN397 linear probing
- support ImageFolder and CoOp-style JSON split inputs, source/unlearned checkpoints, lp/ff modes, and transfer checkpoint/result output
- document transfer usage and update the repro skill generator with transfer commands

## Tests
- python -m py_compile main.py src/core/arg_parser.py src/pipelines/transfer_pipeline.py .codex/skills/unlearn-sparse-repro/scripts/generate_repro_commands.py
- python main.py transfer --help
- python /Users/ljcc/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/unlearn-sparse-repro
- python .codex/skills/unlearn-sparse-repro/scripts/generate_repro_commands.py --suite transfer --runs ./runs/repro --data ./data --seeds 1
- local 2-class ImageFolder 1-epoch transfer smoke test
- git diff --check

Stacked on #16.